### PR TITLE
Add safe start

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,8 @@ Returns an array of detailed user data matching the given ids.
     }
 ]
 ```
+
+Please note: Whilst the project does not contain any explicit content, it does use images
+that might draw unwanted attention in some countries. If you are worried about running this
+project, you can use `npm run safe-start` to replace socially contentious content with something
+less so.

--- a/lib/users-service.js
+++ b/lib/users-service.js
@@ -20,10 +20,24 @@ const OMITTED_FROM_SEARCH = ['headline', 'location', 'personal', 'sexual'];
 
 const OMITTED_FROM_PROFILES = ['name', 'picture', 'online_status', 'last_login'];
 
+/**
+ * Safe start mode for candidates in risky places/situations
+ */
+const makePicturesSafe = (items) => {
+  if (process.env === undefined || process.env.SAFE === undefined) return items;
+
+  return items.map((item) => ({
+    ...item,
+    picture: {
+      ...item.picture,
+      url: item.picture?.url.replace("gay,man", "cat,kitten") || "",
+    },
+  }));
+};
 
 class UsersService {
   constructor() {
-    this._hashIds = new Hashids('pdk87v4kCU', 32);
+    this._hashIds = new Hashids("pdk87v4kCU", 32);
   }
 
   /**
@@ -38,21 +52,29 @@ class UsersService {
   search({ sorting, length, offset = 0 }) {
     // Sort by ascending distance _or_ descending login time
     let sorted = _.sortBy(USERS, (u) => {
-      return sorting === 'DISTANCE' ? u.location.distance : -new Date(u.last_login).getTime();
+      return sorting === "DISTANCE"
+        ? u.location.distance
+        : -new Date(u.last_login).getTime();
     });
 
     let sliced = sorted.slice(offset);
     let hasNext = sliced.length > length;
 
     // Omit some stats from search items!
-    let items = _.take(sliced, length).map(item => _.omit(item, ...OMITTED_FROM_SEARCH));
+    let items = _.take(sliced, length).map((item) =>
+      _.omit(item, ...OMITTED_FROM_SEARCH)
+    );
 
     return {
       cursors: hasNext && {
-        after: this._hashIds.encode(offset + length, length, SORTING.indexOf(sorting))
+        after: this._hashIds.encode(
+          offset + length,
+          length,
+          SORTING.indexOf(sorting)
+        ),
       },
-      items,
-      total: USERS.length
+      items: makePicturesSafe(items),
+      total: USERS.length,
     };
   }
 
@@ -64,7 +86,7 @@ class UsersService {
    * @return {Object} { cursors, items, total }
    */
   scroll(cursor) {
-    let [ offset, length, sortingIdx ] = this._hashIds.decode(cursor);
+    let [offset, length, sortingIdx] = this._hashIds.decode(cursor);
 
     // Only run a search if we're able to decode cursor correctly!
     if (!_.isUndefined(offset)) {
@@ -82,13 +104,15 @@ class UsersService {
    * @return {Array}
    */
   getFullProfilesByIds(ids) {
-    return _(ids)
+    const items = _(ids)
       .castArray()
-      .map(id => USERS_BY_ID[id])
+      .map((id) => USERS_BY_ID[id])
       .compact()
-      .map(item => _.omit(item, OMITTED_FROM_PROFILES))
+      .map((item) => _.omit(item, OMITTED_FROM_PROFILES))
       .shuffle()
       .value();
+
+      return makePicturesSafe(items);
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Erasys JavaScript Trial Task",
   "main": "index.js",
   "scripts": {
-    "start": "node ./index | bunyan"
+    "start": "node ./index | bunyan",
+    "safe-start": "SAFE=1 node ./index | bunyan"
   },
   "author": "erasys GmbH",
   "license": "ISC",


### PR DESCRIPTION
Adds a safe-start script which replaces LGBT content (pride flags etc) with something more neutral (cats) for candidates who are applying from regions where visibly LGBT content might be socially sensitive